### PR TITLE
Added a check to the CidaAuthRequestInterceptor

### DIFF
--- a/src/main/java/gov/usgs/aqcu/Controller.java
+++ b/src/main/java/gov/usgs/aqcu/Controller.java
@@ -5,7 +5,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,7 +16,6 @@ import gov.usgs.aqcu.builder.ReportBuilderService;
 import gov.usgs.aqcu.client.JavaToRClient;
 import gov.usgs.aqcu.model.DvHydrographReport;
 import gov.usgs.aqcu.parameter.DvHydrographRequestParameters;
-import gov.usgs.aqcu.security.CidaAuthAuthenticationToken;
 
 @RestController
 @RequestMapping("/dvhydro")

--- a/src/main/java/gov/usgs/aqcu/security/CidaAuthRequestInterceptor.java
+++ b/src/main/java/gov/usgs/aqcu/security/CidaAuthRequestInterceptor.java
@@ -11,8 +11,9 @@ public class CidaAuthRequestInterceptor implements RequestInterceptor {
 
 	@Override
 	public void apply(RequestTemplate template) {
-		CidaAuthAuthenticationToken auth = (CidaAuthAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
-		template.header(CidaAuthTokenSecurityFilter.AUTHORIZATION_HEADER, CidaAuthTokenSecurityFilter.AUTH_BEARER_STRING + auth.getToken());
+		if(SecurityContextHolder.getContext().getAuthentication() instanceof CidaAuthAuthenticationToken) {
+			CidaAuthAuthenticationToken auth = (CidaAuthAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+			template.header(CidaAuthTokenSecurityFilter.AUTHORIZATION_HEADER, CidaAuthTokenSecurityFilter.AUTH_BEARER_STRING + auth.getToken());
+		}
 	}
-
 }


### PR DESCRIPTION
@dsteinich Not sure if this is a good idea to add or not.. But I think it at least makes the issue a bit clearer to understand in the logs? 

Instead of getting an exception trying to convert an "AnonymousAuthToken" to a "CidaAuthToken" this instead just skips adding any sort of auth to the request headers when no CidaAuthToken is available and this should in-turn cause the downstream request to return a 401. Comparison of the error in the logs:

Before:
```
2018-05-04 18:41:38.757 ERROR 68 --- [nio-7502-exec-7] o.a.c.c.C.[.[.[/].[dispatcherServlet] : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is com.netflix.hystrix.exception.HystrixRuntimeException: NwisRaClient#getParameters(String) failed and no fallback available.] with root cause

java.lang.ClassCastException: org.springframework.security.authentication.AnonymousAuthenticationToken cannot be cast to gov.usgs.aqcu.security.CidaAuthAuthenticationToken
```

After:
```
2018-05-04 15:44:18.856 ERROR 50108 --- [-nio-443-exec-5] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is com.netflix.hystrix.exception.HystrixRuntimeException: NwisRaClient#getParameters(String) failed and no fallback available.] with root cause

feign.FeignException: status 401 reading NwisRaClient#getParameters(String); content:
User cannot access the resource.
```