### PR TITLE
Added a default Aquarius timeout.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ aquarius:
     password: ${aquariusServicePassword}
     retries:
       unauthorized: ${aquariusUnauthorizedRetires:3}
+    timeout: 30000
 
 nwis-ra:
   service:


### PR DESCRIPTION
This report was already on the latest framework snapshot.