### PR TITLE
Updated to SpringBoot 2.x and latest AQCU Framework.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,8 @@
         <additionalparam>-Xdoclint:none</additionalparam>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <springfox.version>2.8.0</springfox.version>
-        <aquarius.sdk.version>18.8.1</aquarius.sdk.version>
-        <aqcu.framework.version>0.0.6-SNAPSHOT</aqcu.framework.version>
-        <spring.boot.version>1.5.13.RELEASE</spring.boot.version>
+        <aqcu.framework.version>0.0.8-SNAPSHOT</aqcu.framework.version>
+        <spring.boot.version>2.2.0.RELEASE</spring.boot.version>
     </properties>
 
     <distributionManagement>
@@ -48,23 +47,23 @@
         <repository>
             <id>aqcu-maven-centralized</id>
             <name>AQCU Maven Centralized (Artifactor)</name>
-            <url>${wma.artifactory.url}/aqcu-maven-centralized/</url>
+            <url>https://cida.usgs.gov/artifactory/aqcu-maven-centralized/</url>
         </repository>
     </repositories>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-parent</artifactId>
-                <version>${spring.boot.version}</version>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>Greenwich.SR3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Edgware.SR3</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -73,98 +72,54 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-oauth2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>gov.usgs.aqcu</groupId>
             <artifactId>aqcu-framework</artifactId>
             <version>${aqcu.framework.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-config</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-hystrix-dashboard</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-zuul</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-feign</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.github.openfeign</groupId>
-            <artifactId>feign-httpclient</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.retry</groupId>
-            <artifactId>spring-retry</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
             <version>${springfox.version}</version>
         </dependency>
-
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
             <version>${springfox.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-tomcat</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>webjars-locator</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.aquaticinformatics</groupId>
-            <artifactId>aquarius.sdk</artifactId>
-            <version>${aquarius.sdk.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-
         <!--  Testing/Development  -->
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <optional>true</optional>
+            <groupId>gov.usgs.aqcu</groupId>
+            <artifactId>aqcu-framework</artifactId>
+            <version>${aqcu.framework.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>5.2.1.RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/gov/usgs/aqcu/Application.java
+++ b/src/main/java/gov/usgs/aqcu/Application.java
@@ -2,14 +2,10 @@ package gov.usgs.aqcu;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.netflix.feign.EnableFeignClients;
-import org.springframework.cloud.netflix.hystrix.EnableHystrix;
-import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
-@EnableHystrixDashboard
 @EnableFeignClients
-@EnableHystrix
 public class Application {
 
 	public static void main(String[] args) throws Exception {

--- a/src/main/java/gov/usgs/aqcu/builder/ReportBuilderService.java
+++ b/src/main/java/gov/usgs/aqcu/builder/ReportBuilderService.java
@@ -23,6 +23,7 @@ import com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.Time
 import com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.TimeSeriesDescription;
 import com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.TimeSeriesPoint;
 
+import gov.usgs.aqcu.model.DataGap;
 import gov.usgs.aqcu.model.DvHydrographPoint;
 import gov.usgs.aqcu.model.DvHydrographReport;
 import gov.usgs.aqcu.model.DvHydrographReportMetadata;
@@ -360,8 +361,13 @@ public class ReportBuilderService {
 		timeSeriesCorrectedData.setVolumetricFlow(isVolumetricFlow);
 
 		timeSeriesCorrectedData.setApprovals(timeSeriesDataServiceResponse.getApprovals());
-		timeSeriesCorrectedData.setGaps(
-				dataGapListBuilderService.buildGapList(timeSeriesDataServiceResponse.getPoints(), isDaily, zoneOffset));
+
+		List<DataGap> gaps = dataGapListBuilderService.buildGapList(timeSeriesDataServiceResponse.getPoints(), isDaily, zoneOffset);
+
+		if(!gaps.isEmpty()) {
+			timeSeriesCorrectedData.setGaps(gaps);
+		}
+		
 		timeSeriesCorrectedData.setGapTolerances(timeSeriesDataServiceResponse.getGapTolerances());
 
 		return timeSeriesCorrectedData;

--- a/src/main/java/gov/usgs/aqcu/config/WebMvcConfig.java
+++ b/src/main/java/gov/usgs/aqcu/config/WebMvcConfig.java
@@ -11,8 +11,6 @@ import org.springframework.http.converter.json.GsonHttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
-import org.springframework.web.servlet.resource.WebJarsResourceResolver;
 
 import com.google.gson.Gson;
 
@@ -21,26 +19,19 @@ import gov.usgs.aqcu.util.AqcuGsonBuilderFactory;
 import springfox.documentation.spring.web.json.Json;
 
 @Configuration
-public class WebMvcConfig extends WebMvcConfigurerAdapter {
-
-	@Bean
-	public WebMvcConfigurer corsConfigurer() {
-		return new WebMvcConfigurerAdapter() {
-			@Override
-			public void addCorsMappings(CorsRegistry registry) {
-				registry.addMapping("/**");
-			}
-		};
+public class WebMvcConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**");
 	}
 
 	@Override
 	public void addResourceHandlers(ResourceHandlerRegistry registry) {
 		registry.addResourceHandler("/static/**")
-				.addResourceLocations("/resources/", "/webjars/")
+				.addResourceLocations("/resources/")
 				.setCacheControl(
 						CacheControl.maxAge(30L, TimeUnit.DAYS).cachePublic())
-				.resourceChain(true)
-				.addResolver(new WebJarsResourceResolver());
+				.resourceChain(true);
 	}
 
 	@Override
@@ -54,7 +45,6 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
 	public Gson gson() {
 		return AqcuGsonBuilderFactory.getConfiguredGsonBuilder()
 			.registerTypeAdapter(Json.class, new SwaggerGsonSerializer())
-			.serializeNulls()
 			.create();
 	}
 }

--- a/src/main/java/gov/usgs/aqcu/serializer/SwaggerGsonSerializer.java
+++ b/src/main/java/gov/usgs/aqcu/serializer/SwaggerGsonSerializer.java
@@ -14,7 +14,6 @@ public class SwaggerGsonSerializer implements JsonSerializer<Json> {
 	public JsonElement serialize(Json json, Type type, JsonSerializationContext context) {
 		//This is needed to fix a known bug with Swagger and the Spring GsonHttpMessageConverter
 		//See: https://github.com/springfox/springfox/issues/1608
-		final JsonParser parser = new JsonParser();
-		return parser.parse(json.value());
+		return JsonParser.parseString(json.value());
 	}
 }

--- a/src/test/java/gov/usgs/aqcu/DVHydroControllerTest.java
+++ b/src/test/java/gov/usgs/aqcu/DVHydroControllerTest.java
@@ -16,6 +16,8 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -23,6 +25,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.FileCopyUtils;
 
 import gov.usgs.aqcu.builder.ReportBuilderService;
@@ -32,7 +35,9 @@ import gov.usgs.aqcu.parameter.DvHydrographRequestParameters;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(DVHydroController.class)
-@AutoConfigureMockMvc(secure=false)
+@WithMockUser
+@EnableAutoConfiguration(exclude = {SecurityAutoConfiguration.class})
+@AutoConfigureMockMvc
 public class DVHydroControllerTest {
 
 	@Autowired
@@ -109,7 +114,7 @@ public class DVHydroControllerTest {
 	@Test
 	public void getRequestingUserTest() {
 		DVHydroController c = new DVHydroController(null, null, null);
-		assertEquals(DVHydroController.UNKNOWN_USERNAME, c.getRequestingUser());
+		assertEquals("user", c.getRequestingUser());
 	}
 
 }

--- a/src/test/java/gov/usgs/aqcu/FiveYearControllerTest.java
+++ b/src/test/java/gov/usgs/aqcu/FiveYearControllerTest.java
@@ -16,10 +16,13 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -32,7 +35,9 @@ import gov.usgs.aqcu.parameter.FiveYearRequestParameters;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(FiveYearController.class)
-@AutoConfigureMockMvc(secure=false)
+@WithMockUser
+@EnableAutoConfiguration(exclude = {SecurityAutoConfiguration.class})
+@AutoConfigureMockMvc
 public class FiveYearControllerTest {
 
 	@Autowired
@@ -109,7 +114,7 @@ public class FiveYearControllerTest {
 	@Test
 	public void getRequestingUserTest() {
 		DVHydroController c = new DVHydroController(null, null, null);
-		assertEquals(DVHydroController.UNKNOWN_USERNAME, c.getRequestingUser());
+		assertEquals("user", c.getRequestingUser());
 	}
 
 }

--- a/src/test/java/gov/usgs/aqcu/builder/ReportBuilderServiceTest.java
+++ b/src/test/java/gov/usgs/aqcu/builder/ReportBuilderServiceTest.java
@@ -144,7 +144,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void buildReportNoNwisRaTest() {
 		given(parameterListService.getParameterMetadata()).willReturn(getParameterMetadata());
 		given(timeSeriesDescriptionService.getTimeSeriesDescriptions(any(DvHydrographRequestParameters.class)))
@@ -180,7 +179,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void buildGwExcludedReportTest() {
 		given(parameterListService.getParameterMetadata()).willReturn(getParameterMetadata());
 		given(timeSeriesDescriptionService.getTimeSeriesDescriptions(any(DvHydrographRequestParameters.class)))
@@ -220,7 +218,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void buildGwReportTest() {
 		given(parameterListService.getParameterMetadata()).willReturn(getParameterMetadata());
 		given(timeSeriesDescriptionService.getTimeSeriesDescriptions(any(DvHydrographRequestParameters.class)))
@@ -262,7 +259,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void buildWqExcludedReportTest() {
 		given(parameterListService.getParameterMetadata()).willReturn(getParameterMetadata());
 		given(timeSeriesDescriptionService.getTimeSeriesDescriptions(any(DvHydrographRequestParameters.class)))
@@ -272,7 +268,7 @@ public class ReportBuilderServiceTest {
 						getTimeSeriesDataServiceResponse(false, ZoneOffset.of("-4"), false));
 		given(locationDescriptionListService.getByLocationIdentifier(anyString()))
 			.willReturn(new LocationDescription().setIdentifier("0010010000").setName("monitoringLocation"));
-		given(dataGapListBuilderService.buildGapList(anyList(), any(boolean.class), any(ZoneOffset.class)))
+		given(dataGapListBuilderService.buildGapList(eq(null), any(boolean.class), any(ZoneOffset.class)))
 			.willReturn(getGapList());
 		given(qualifierLookupService.getByQualifierList(anyList())).willReturn(metadataMap);
 
@@ -290,7 +286,7 @@ public class ReportBuilderServiceTest {
 		verify(timeSeriesDescriptionService).getTimeSeriesDescriptions(any(DvHydrographRequestParameters.class));
 		verify(timeSeriesDataService, times(2)).get(anyString(), any(DvHydrographRequestParameters.class), any(ZoneOffset.class), any(boolean.class), any(boolean.class), any(boolean.class), eq(null));
 		verify(locationDescriptionListService).getByLocationIdentifier(anyString());
-		verify(dataGapListBuilderService, times(1)).buildGapList(anyList(), any(boolean.class), any(ZoneOffset.class));
+		verify(dataGapListBuilderService, times(1)).buildGapList(eq(null), any(boolean.class), any(ZoneOffset.class));
 		verify(qualifierLookupService).getByQualifierList(anyList());
 		verify(fieldVisitDataService, never()).get(anyString());
 		verify(fieldVisitDescriptionService, never()).getDescriptions(anyString(), any(ZoneOffset.class), any(DvHydrographRequestParameters.class));
@@ -302,7 +298,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void buildWqNoPcodeReportTest() {
 		ParameterRecord pcodeA = new ParameterRecord();
 		pcodeA.setName("nwisName");
@@ -320,7 +315,7 @@ public class ReportBuilderServiceTest {
 						getTimeSeriesDataServiceResponse(false, ZoneOffset.of("-4"), false));
 		given(locationDescriptionListService.getByLocationIdentifier(anyString()))
 			.willReturn(new LocationDescription().setIdentifier("0010010000").setName("monitoringLocation"));
-		given(dataGapListBuilderService.buildGapList(anyList(), any(boolean.class), any(ZoneOffset.class)))
+		given(dataGapListBuilderService.buildGapList(eq(null), any(boolean.class), any(ZoneOffset.class)))
 			.willReturn(getGapList());
 		given(qualifierLookupService.getByQualifierList(anyList())).willReturn(metadataMap);
 		given(nwisRaService.getQwData(any(DvHydrographRequestParameters.class), anyString(), anyString(), any(ZoneOffset.class)))
@@ -342,7 +337,7 @@ public class ReportBuilderServiceTest {
 		verify(timeSeriesDescriptionService).getTimeSeriesDescriptions(any(DvHydrographRequestParameters.class));
 		verify(timeSeriesDataService, times(2)).get(anyString(), any(DvHydrographRequestParameters.class), any(ZoneOffset.class), any(boolean.class), any(boolean.class), any(boolean.class), eq(null));
 		verify(locationDescriptionListService).getByLocationIdentifier(anyString());
-		verify(dataGapListBuilderService, times(1)).buildGapList(anyList(), any(boolean.class), any(ZoneOffset.class));
+		verify(dataGapListBuilderService, times(1)).buildGapList(eq(null), any(boolean.class), any(ZoneOffset.class));
 		verify(qualifierLookupService).getByQualifierList(anyList());
 		verify(fieldVisitDataService, never()).get(anyString());
 		verify(fieldVisitDescriptionService, never()).getDescriptions(anyString(), any(ZoneOffset.class), any(DvHydrographRequestParameters.class));
@@ -354,7 +349,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void buildWqReportTest() {
 		ParameterRecord pcodeA = new ParameterRecord();
 		pcodeA.setName("nwisName");
@@ -372,7 +366,7 @@ public class ReportBuilderServiceTest {
 						getTimeSeriesDataServiceResponse(false, ZoneOffset.of("-4"), false));
 		given(locationDescriptionListService.getByLocationIdentifier(anyString()))
 			.willReturn(new LocationDescription().setIdentifier("0010010000").setName("monitoringLocation"));
-		given(dataGapListBuilderService.buildGapList(anyList(), any(boolean.class), any(ZoneOffset.class)))
+		given(dataGapListBuilderService.buildGapList(eq(null), any(boolean.class), any(ZoneOffset.class)))
 			.willReturn(getGapList());
 		given(qualifierLookupService.getByQualifierList(anyList())).willReturn(metadataMap);
 		given(nwisRaService.getQwData(any(DvHydrographRequestParameters.class), anyString(), anyString(), any(ZoneOffset.class)))
@@ -394,7 +388,7 @@ public class ReportBuilderServiceTest {
 		verify(timeSeriesDescriptionService).getTimeSeriesDescriptions(any(DvHydrographRequestParameters.class));
 		verify(timeSeriesDataService, times(2)).get(anyString(), any(DvHydrographRequestParameters.class), any(ZoneOffset.class), any(boolean.class), any(boolean.class), any(boolean.class), eq(null));
 		verify(locationDescriptionListService).getByLocationIdentifier(anyString());
-		verify(dataGapListBuilderService, times(1)).buildGapList(anyList(), any(boolean.class), any(ZoneOffset.class));
+		verify(dataGapListBuilderService, times(1)).buildGapList(eq(null), any(boolean.class), any(ZoneOffset.class));
 		verify(qualifierLookupService).getByQualifierList(anyList());
 		verify(fieldVisitDataService, never()).get(anyString());
 		verify(fieldVisitDescriptionService, never()).getDescriptions(anyString(), any(ZoneOffset.class), any(DvHydrographRequestParameters.class));
@@ -413,22 +407,21 @@ public class ReportBuilderServiceTest {
 
 	@Test
 	public void buildTimeSeriesCorrectedDataNotFoundAqTest() {
-		given(timeSeriesDataService.get(anyString(), any(DvHydrographRequestParameters.class), any(ZoneOffset.class),
+		given(timeSeriesDataService.get(anyString(), eq(null), any(ZoneOffset.class),
 				any(boolean.class), any(boolean.class), any(boolean.class), eq(null))).willReturn(null);
 		Map<String, TimeSeriesDescription> descriptions = new HashMap<>();
 		descriptions.put("abc", new TimeSeriesDescription());
 		assertNull(service.buildTimeSeriesCorrectedData(descriptions, "abc", null, null));
-		verify(timeSeriesDataService).get(anyString(), any(DvHydrographRequestParameters.class), any(ZoneOffset.class),
+		verify(timeSeriesDataService).get(anyString(), eq(null), any(ZoneOffset.class),
 		any(boolean.class), any(boolean.class), any(boolean.class), eq(null));
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void buildTimeSeriesCorrectedDataTest() {
 		boolean endOfPeriod = false;
 		ZoneOffset zoneOffset = ZoneOffset.UTC;
 
-		given(timeSeriesDataService.get(anyString(), any(DvHydrographRequestParameters.class), any(ZoneOffset.class),
+		given(timeSeriesDataService.get(anyString(), eq(null), any(ZoneOffset.class),
 		any(boolean.class), any(boolean.class), any(boolean.class), eq(null)))
 						.willReturn(getTimeSeriesDataServiceResponse(endOfPeriod, zoneOffset, true));
 		given(dataGapListBuilderService.buildGapList(anyList(), any(boolean.class), any(ZoneOffset.class)))
@@ -442,7 +435,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void createDvHydroMetadataFirstTest() {
 		given(locationDescriptionListService.getByLocationIdentifier(anyString()))
 			.willReturn(new LocationDescription().setIdentifier("0010010000").setName("monitoringLocation"));
@@ -458,7 +450,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void createDvHydroMetadataSecondTest() {
 		given(locationDescriptionListService.getByLocationIdentifier(anyString()))
 			.willReturn(new LocationDescription().setIdentifier("0010010000").setName("monitoringLocation"));
@@ -476,7 +467,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void createDvHydroMetadataThirdTest() {
 		given(locationDescriptionListService.getByLocationIdentifier(anyString()))
 			.willReturn(new LocationDescription().setIdentifier("0010010000").setName("monitoringLocation"));
@@ -497,7 +487,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void createTimeSeriesCorrectedDataSparseTest() {
 		given(dataGapListBuilderService.buildGapList(anyList(), any(boolean.class), any(ZoneOffset.class))).willReturn(null);
 		TimeSeriesDataServiceResponse tsd = new TimeSeriesDataServiceResponse();
@@ -508,7 +497,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void createTimeSeriesCorrectedDataTsUtcTest() {
 		given(dataGapListBuilderService.buildGapList(anyList(), any(boolean.class), any(ZoneOffset.class)))
 				.willReturn(getGapList());
@@ -523,7 +511,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void createTimeSeriesCorrectedDataDvZ6Test() {
 		given(dataGapListBuilderService.buildGapList(anyList(), any(boolean.class), any(ZoneOffset.class)))
 		.willReturn(getGapList());
@@ -543,7 +530,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void createDvHydroPointsDvUtcTest() {
 		List<DvHydrographPoint> actual = service.createDvHydroPoints(getTimeSeriesPoints(true, ZoneOffset.UTC), true,
 				ZoneOffset.UTC);
@@ -555,7 +541,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void createDvHydroPointsTsCtTest() {
 		boolean endOfPeriod = true;
 		ZoneOffset zoneOffset = ZoneOffset.of("-6");
@@ -575,7 +560,6 @@ public class ReportBuilderServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void getEstimatedPeriodsTest() {
 		List<InstantRange> actual = service.getEstimatedPeriods(getQualifiers());
 		assertEquals(5, actual.size());
@@ -699,6 +683,7 @@ public class ReportBuilderServiceTest {
 	protected TimeSeriesDescription buildPrimarySeriesDescription() {
 		return new TimeSeriesDescription()
 				.setIdentifier("primaryIdentifier")
+				.setLocationIdentifier("location")
 				.setUtcOffset(Double.valueOf(-4))
 				.setParameter("Discharge");
 	}

--- a/src/test/java/gov/usgs/aqcu/validation/DvHydroRequestParametersValidationTest.java
+++ b/src/test/java/gov/usgs/aqcu/validation/DvHydroRequestParametersValidationTest.java
@@ -1,7 +1,8 @@
 package gov.usgs.aqcu.validation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.in;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -69,7 +70,7 @@ public class DvHydroRequestParametersValidationTest {
 				.stream()
 				.map(x -> String.join(":", x.getPropertyPath().toString(), x.getMessage()))
 				.collect(Collectors.toList());
-		assertThat(expected, isIn(actualStrings));
+		assertThat(expected, is(in(actualStrings)));
 	}
 
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,8 @@
 nwisRaServiceEndpoint: https://usgs.gov/nwisra
 javaToRServiceEndpoint: https://usgs.gov/javaToR
-
+security:
+  basic:
+    enabled: false
 aquarius:
   service:
     endpoint: https://usgs.gov/aquarius


### PR DESCRIPTION
Fairly extensive updates to tests because in the new version of hamcrest matchers `any()` and `any___()` (such as `anyList()`) don't match with null like they used to. Now you have to explicitly expect a function to be called with null instead.